### PR TITLE
Fix homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 <p align="center">
     <a href="https://github.com/fasten-project/fasten-web/actions" alt="GitHub Workflow Status">
         <img src="https://img.shields.io/github/workflow/status/fasten-project/fasten-web/React%20CI?logo=GitHub%20Actions&logoColor=white&style=for-the-badge" /></a>
-    <a href="https://fasten-project.github.io/fasten-web/" alt="FASTEN Project Web">
-        <img alt="Website" src="https://img.shields.io/website?down_message=Offline&style=for-the-badge&up_message=Online&url=https%3A%2F%2Ffasten-project.github.io%2Ffasten-web%2F"></a>
+    <a href="https://demo.fasten-project.eu/" alt="FASTEN Project Web">
+        <img alt="Website" src="https://img.shields.io/website?down_message=Offline&style=for-the-badge&up_message=Online&url=https%3A%2F%2Fdemo.fasten-project.eu"></a>
     <a href="https://github.com/fasten-project/fasten-web/" alt="Gitter">
             <img src="https://img.shields.io/gitter/room/fasten-project/fasten-web?style=for-the-badge&logo=gitter" /></a>
 </p>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fasten-web",
   "version": "0.1.0",
-  "homepage": "https://fasten-project.github.io/fasten-web",
+  "homepage": "https://demo.fasten-project.eu",
   "repository": {
     "type": "git",
     "url": "http://github.com/fasten-project/fasten-web"

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,6 @@
 const config = {
-  api: "http://127.0.0.1:8080",
+  // api: "http://127.0.0.1:8080",
+  api: "http://api.fasten-project.eu/api",
   git: "https://github.com/fasten-project/",
   webpage: "http://fasten-project.eu/",
 };


### PR DESCRIPTION
## Description
For a better look and intuitive experience, the domain for the website was moved to custom domain, [demo.fasten-project.eu](https://fasten-project.eu). The PR adjusts `homepage` at `package.json` as well as website monitoring badge in README. In addition, it changes the API's baseurl from the same domain, [api.fasten-project.eu]().

## Task list  
- [X] Request OW2 for changes in DNS ([OW2 Gitlab Issue](https://gitlab.ow2.org/fasten/fasten/-/issues/1))
- [X] Configure custom domain at Github Pages
- [X] Adjust homepage url in the project
