### PR TITLE
Fix Rest API urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 [The FASTEN project](https://github.com/fasten-project/fasten) is an intelligent software package management systems that enhance robustness and security in software ecosystems. This frontend project helps to fully utilise these systems and visualises all the valuable data that is provided. This web platform can be used by the end developers in order to get fine grained data about the vurnalabilities that one uses in a visual and clear way.
 
-Homepage: https://fasten-project.github.io/fasten-web/
+Homepage: [demo.fasten-project.eu](https://demo.fasten-project.eu/)
 
 ## Getting Started
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
 const config = {
   // api: "http://127.0.0.1:8080",
-  api: "http://api.fasten-project.eu/api",
+  api: "http://api.fasten-project.eu",
   git: "https://github.com/fasten-project/",
   webpage: "http://fasten-project.eu/",
 };

--- a/src/requests/services/package.ts
+++ b/src/requests/services/package.ts
@@ -7,21 +7,21 @@ import { isValidCallablesResponsePayload } from "../payloads/package-callable-pa
 
 /**
  * Endpoint for retrieving the package entity.
- * Requires additional parameters: `/mvn/packages/{name}`.
+ * Requires additional parameters: `/api/mvn/packages/{name}`.
  */
-export const PACKAGE_ENDPOINT = "/mvn/packages/{0}";
+export const PACKAGE_ENDPOINT = "/api/mvn/packages/{0}";
 
 /**
  * Endpoint for retrieving the package modules.
- * Requires additional parameters: `/mvn/packages/{name}/{version}/modules`.
+ * Requires additional parameters: `/api/mvn/packages/{name}/{version}/modules`.
  */
-export const PACKAGE_MODULES_ENDPOINT = "/mvn/packages/{0}/{1}/modules";
+export const PACKAGE_MODULES_ENDPOINT = "/api/mvn/packages/{0}/{1}/modules";
 
 /**
  * Endpoint for retrieving the package callables.
- * Requires additional parameters: `/mvn/packages/{name}/{version}/callables`.
+ * Requires additional parameters: `/api/mvn/packages/{name}/{version}/callables`.
  */
-export const PACKAGE_CALLABLES_ENDPOINT = "/mvn/packages/{0}/{1}/callables";
+export const PACKAGE_CALLABLES_ENDPOINT = "/api/mvn/packages/{0}/{1}/callables";
 
 /**
  * The request for retrieving the package entity.


### PR DESCRIPTION
## Description
The PR fixes Rest API urls to properly include trailing `api` path for each endpoint. The PR also changes homepage url in README to a new one.