### PR TITLE
Enforce http in app

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,13 +9,21 @@ import {
 
 import { StyledAppContainer } from "./App.styled";
 import { Home } from "./routes/Home";
-import { Package } from "./routes/Package";
+import { Package, PackageProps, PackageState } from "./routes/Package";
 
 export type AppProps = RouteComponentProps & {};
 
 export interface AppState {}
 
 class InternalApp extends React.Component<AppProps, AppState> {
+  constructor(props: AppProps, state: AppState) {
+    super(props, state);
+    const url = window.location.origin;
+    if (url.includes("https")) {
+      window.location.href = `http:${url.split(":")[1]}`;
+    }
+  }
+
   render() {
     const location = this.props.location;
 


### PR DESCRIPTION
## Description
An attempt to enforce HTTP instead of HTTPS.

## Motivation and context
Rest API is currently served only through HTTP. When the frontend is at HTTPS, there is a mix in security layers issue, which causes a block of Rest API response as it is insecure.

**Revert when Rest API will support HTTPS.**
