### PR TITLE
Quickfix: remove unused imports

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,7 @@ import {
 
 import { StyledAppContainer } from "./App.styled";
 import { Home } from "./routes/Home";
-import { Package, PackageProps, PackageState } from "./routes/Package";
+import { Package } from "./routes/Package";
 
 export type AppProps = RouteComponentProps & {};
 


### PR DESCRIPTION
## Description
Quickfix for #28. Removes unused imports as the pipeline was throwing errors on them.
