### PR TITLE
Fix mixed security

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
 const config = {
   // api: "http://127.0.0.1:8080",
-  api: "http://api.fasten-project.eu",
+  api: "https://cors-anywhere.herokuapp.com",
   git: "https://github.com/fasten-project/",
   webpage: "http://fasten-project.eu/",
 };

--- a/src/requests/services/package.ts
+++ b/src/requests/services/package.ts
@@ -9,19 +9,21 @@ import { isValidCallablesResponsePayload } from "../payloads/package-callable-pa
  * Endpoint for retrieving the package entity.
  * Requires additional parameters: `/api/mvn/packages/{name}`.
  */
-export const PACKAGE_ENDPOINT = "/api/mvn/packages/{0}";
+export const PACKAGE_ENDPOINT = "api.fasten-project.eu/api/mvn/packages/{0}";
 
 /**
  * Endpoint for retrieving the package modules.
  * Requires additional parameters: `/api/mvn/packages/{name}/{version}/modules`.
  */
-export const PACKAGE_MODULES_ENDPOINT = "/api/mvn/packages/{0}/{1}/modules";
+export const PACKAGE_MODULES_ENDPOINT =
+  "api.fasten-project.eu/api/mvn/packages/{0}/{1}/modules";
 
 /**
  * Endpoint for retrieving the package callables.
  * Requires additional parameters: `/api/mvn/packages/{name}/{version}/callables`.
  */
-export const PACKAGE_CALLABLES_ENDPOINT = "/api/mvn/packages/{0}/{1}/callables";
+export const PACKAGE_CALLABLES_ENDPOINT =
+  "api.fasten-project.eu/api/mvn/packages/{0}/{1}/callables";
 
 /**
  * The request for retrieving the package entity.


### PR DESCRIPTION
## Description
As a replacement to #28 (which was reverted by #30), use heroku's cors-anyhwere service that bypasses cors config. While Rest API is served by HTTP, the frontend uses HTTPS. This causes the response from API to be blocked. Heroku's cors-anywhere, meanwhile, by default is accessed by HTTPS, thus helps to solve the issue.