### PR TITLE
Add CNAME file to persist domain on deploy

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+demo.fasten-project.eu

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "test-with-cov": "yarn jest --passWithNoTests --coverage",
     "fix-lint": "yarn eslint '*/**/*.{js,ts,tsx}' --quiet --fix",
     "lint": "yarn eslint '*/**/*.{js,ts,tsx}'",
-    "build": "react-scripts build",
+    "build": "react-scripts build && cp CNAME build/CNAME",
     "deploy": "gh-pages -d build"
   },
   "eslintConfig": {


### PR DESCRIPTION
## Description
The PR adds a new file in the root directory, `CNAME`. It contains just a line of custom domain, `demo.fasten-project.eu`. And in `build` script (package.json), this file is copied to the build directory.

## Motivation and context
Previously, every `gh-pages` deployment would cause the custom domain to be reset. Thus, every time it needed to be put back manually through the project's settings on GitHub. The PR will fix the bug.
