### PR TITLE
Allow dynamic version selection for the packages

### DIFF
--- a/src/components/Module/Module.tsx
+++ b/src/components/Module/Module.tsx
@@ -2,12 +2,14 @@ import * as React from "react";
 import { withRouter, RouteComponentProps } from "react-router-dom";
 import { Tab, TabMenu } from "../TabMenu";
 import { PackageTable } from "../PackageTable";
-import { Package as PackageModel } from "../../requests/payloads/package-payload";
 import { getModuleCallables } from "../../requests/services/package";
 
 export interface ModuleProps extends RouteComponentProps {
-  /** The package that needs to be taken. */
-  pkg: PackageModel;
+  /** The package name that needs to be taken. */
+  pkg: string;
+
+  /** The package version that needs to be considered. */
+  pkgVer: string;
 
   /** The namespace of the module in focus. */
   namespace: string;
@@ -17,10 +19,10 @@ export interface ModuleState {}
 
 /**
  * The component that renders the content related to the Module level of abstraction.
- * TODO: allow other versions of the package to be chosen (not only default as now).
  */
 class InternalModule extends React.Component<ModuleProps, ModuleState> {
   render() {
+    const { pkg, pkgVer, namespace } = this.props;
     const tabs: Tab[] = [
       {
         label: "Callables",
@@ -28,16 +30,10 @@ class InternalModule extends React.Component<ModuleProps, ModuleState> {
           return (
             <PackageTable
               kind={"CALLABLES"}
-              pkg={this.props.pkg.package_name}
-              pkgVersion={this.props.pkg.version}
-              namespace={this.props.namespace}
-              fetchEntities={() =>
-                getModuleCallables(
-                  this.props.pkg.package_name,
-                  this.props.pkg.version,
-                  this.props.namespace
-                )
-              }
+              pkg={pkg}
+              pkgVersion={pkgVer}
+              namespace={namespace}
+              fetchEntities={() => getModuleCallables(pkg, pkgVer, namespace)}
             />
           );
         },

--- a/src/components/Package/Package.tsx
+++ b/src/components/Package/Package.tsx
@@ -2,12 +2,14 @@ import * as React from "react";
 import { withRouter, RouteComponentProps } from "react-router-dom";
 import { Tab, TabMenu } from "../TabMenu";
 import { PackageTable } from "../PackageTable";
-import { Package as PackageModel } from "../../requests/payloads/package-payload";
 import { getModules } from "../../requests/services/package";
 
 export interface PackageProps extends RouteComponentProps {
-  /** The package that needs to be taken. */
-  pkg: PackageModel;
+  /** The package name that needs to be taken. */
+  pkg: string;
+
+  /** The package version that needs to be considered. */
+  pkgVer: string;
 }
 
 export interface PackageState {}
@@ -24,11 +26,10 @@ class InternalPackage extends React.Component<PackageProps, PackageState> {
           return (
             <PackageTable
               kind={"MODULES"}
-              pkg={this.props.pkg.package_name}
-              // TODO: allow different versions.
-              pkgVersion={this.props.pkg.version}
+              pkg={this.props.pkg}
+              pkgVersion={this.props.pkgVer}
               fetchEntities={() =>
-                getModules(this.props.pkg.package_name, this.props.pkg.version)
+                getModules(this.props.pkg, this.props.pkgVer)
               }
             />
           );

--- a/src/routes/Package/Package.tsx
+++ b/src/routes/Package/Package.tsx
@@ -97,15 +97,23 @@ class InternalPackage extends React.Component<
   }
 
   renderAbstractionContent() {
-    const { moduleParam, callableParam } = this.props.match.params;
+    const { verParam, moduleParam, callableParam } = this.props.match.params;
     const namespace = moduleParam ? decodeURIComponent(moduleParam) : null;
 
     if (callableParam) {
       return <Callable callable={defaultCallable} />;
     } else if (namespace) {
-      return <Module pkg={this.state.pkg} namespace={namespace} />;
+      return (
+        <Module
+          pkg={this.state.pkg.package_name}
+          pkgVer={verParam}
+          namespace={namespace}
+        />
+      );
     } else {
-      return <PackagePage pkg={this.state.pkg} />;
+      return (
+        <PackagePage pkg={this.state.pkg.package_name} pkgVer={verParam} />
+      );
     }
   }
 
@@ -144,14 +152,14 @@ class InternalPackage extends React.Component<
         <NavBar />
         <StyledContainer>
           <StyledTitle>
-            <Link to={`/packages/${pkg.package_name}/${pkg.version}`}>
-              {pkg.project_name} {pkg.version}
+            <Link to={`/packages/${pkg.package_name}/${verParam}`}>
+              {pkg.project_name} {verParam}
             </Link>
             {namespace && (
               <>
                 <span> / </span>
                 <Link
-                  to={`/packages/${pkg.package_name}/${pkg.version}/${moduleParam}`}
+                  to={`/packages/${pkg.package_name}/${verParam}/${moduleParam}`}
                 >
                   {namespace}
                 </Link>
@@ -161,7 +169,7 @@ class InternalPackage extends React.Component<
               <>
                 <span> / </span>
                 <Link
-                  to={`/packages/${pkg.package_name}/${pkg.version}/${moduleParam}/${callableParam}`}
+                  to={`/packages/${pkg.package_name}/${verParam}/${moduleParam}/${callableParam}`}
                 >
                   {fasten_uri}
                 </Link>


### PR DESCRIPTION
## Description
Make the pages reflect the package's version from URL's param (in modules and package pages).

## Motivation and context
Previously, all pages were using the version provided as the latest version from the package instance. This approach limited the ability to freely choose the version one would be interested in.