### PR TITLE
Silence eslint unused vars error for mockup request

### DIFF
--- a/src/requests/services/package.ts
+++ b/src/requests/services/package.ts
@@ -92,6 +92,7 @@ export function getModuleCallables(
  * @param {string} pkg - the name of the package.
  * @param {string} ver - the version of the package.
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function getVulnerabilities(pkg: string, ver: string) {
   return [
     {


### PR DESCRIPTION
## Description
PR continues #37. There was a failed pipeline. This part of PR solves it. The problem was in eslint error that was complaining about unused vars in mockup request for vulnerabilities.