### PR TITLE
Package Search

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import {
 import { StyledAppContainer } from "./App.styled";
 import { Home } from "./routes/Home";
 import { Package } from "./routes/Package";
+import { Search } from "./routes/Search";
 
 export type AppProps = RouteComponentProps & {};
 
@@ -25,6 +26,7 @@ class InternalApp extends React.Component<AppProps, AppState> {
           {/** Redirect the root to our default route */}
           <Route exact path="/" render={() => <Redirect to="/home" />} />
           <Route exact path="/home" key={location.key} component={Home} />
+          <Route exact path="/search" key={location.key} component={Search} />
           <Route
             exact
             path="/packages/:pkgParam/:verParam?/:moduleParam?/:callableParam?"

--- a/src/requests/payloads/package-payload.ts
+++ b/src/requests/payloads/package-payload.ts
@@ -1,4 +1,5 @@
 import * as yup from "yup";
+import { array } from "yup";
 
 /**
  * Validation schema for {@link Package}.
@@ -16,10 +17,10 @@ export const PACKAGE_SCHEMA = yup
     forge: yup.string().required(),
 
     /** Readable project name (e.g., JUnit). */
-    project_name: yup.string().required(),
+    project_name: yup.string().nullable(),
 
     /** The repository source of the package. */
-    repository: yup.string().required(),
+    repository: yup.string().nullable(),
 
     /** The date when the package was published. */
     created_at: yup.date().max(new Date(Date.now())).nullable(),
@@ -28,6 +29,11 @@ export const PACKAGE_SCHEMA = yup
     version: yup.string(),
   })
   .required();
+
+/**
+ * Validation schema for {@link Package[]}.
+ */
+export const PACKAGE_ARRAY_SCHEMA = array().of(PACKAGE_SCHEMA);
 
 /**
  * The type of the Package instance generated from yup schema {@link PACKAGE_SCHEMA}.
@@ -55,4 +61,15 @@ export function isValidPackageResponsePayload(
   payload: any
 ): payload is Package {
   return PACKAGE_SCHEMA.isValidSync(payload);
+}
+
+/**
+ * Validates that the given response payload is as expected.
+ * @param {any} payload - the response payload.
+ * @returns {boolean} - whether or not the payload is type-safe for {@link Package[]}.
+ */
+export function isValidPackagesArrayResponsePayload(
+  payload: any
+): payload is Package[] {
+  return PACKAGE_ARRAY_SCHEMA.isValidSync(payload);
 }

--- a/src/requests/services/search.ts
+++ b/src/requests/services/search.ts
@@ -1,0 +1,17 @@
+import { String } from "typescript-string-operations";
+import config from "../../config";
+import { sendRequest } from "../utils";
+import { isValidPackagesArrayResponsePayload } from "../payloads/package-payload";
+
+export const SEARCH_ENDPOINT =
+  config.apiSuffix + "/mvn/packages/search?packageName={0}";
+
+export function getSuggestions(query: string) {
+  return sendRequest(
+    "get",
+    String.Format(SEARCH_ENDPOINT, query),
+    config.api,
+    isValidPackagesArrayResponsePayload,
+    {}
+  );
+}

--- a/src/routes/Home/Home.tsx
+++ b/src/routes/Home/Home.tsx
@@ -56,7 +56,7 @@ class InternalHome extends React.Component<
    */
   handleSearch(e: React.KeyboardEvent) {
     if (e.key == "Enter")
-      this.props.history.push(`/packages/${this.state.searchQuery}`);
+      this.props.history.push(`/search?query=${this.state.searchQuery}`);
   }
 
   render() {

--- a/src/routes/Search/Search.styled.ts
+++ b/src/routes/Search/Search.styled.ts
@@ -1,0 +1,77 @@
+import styled from "@emotion/styled";
+import metrics from "../../theme/metrics";
+import colours from "../../theme/colours";
+
+export const StyledContainer = styled.div({
+  width: "60%",
+  margin: "15px auto",
+  "& a": {
+    color: colours.primary,
+    textDecoration: "none",
+    ":hover": {
+      filter: "brightness(85%)",
+    },
+  },
+});
+
+/**
+ * Text Field element
+ */
+export const StyledSeachBarInput = styled.div({
+  position: "relative",
+  width: "100%",
+  zIndex: 1,
+  margin: "10px auto",
+  marginBottom: metrics.margin.lg,
+
+  // Input Field
+  "& input": {
+    boxSizing: "border-box",
+    outline: "none",
+    border: "none",
+
+    fontSize: metrics.fontSize.xxl,
+    color: "#666666",
+    display: "block",
+    width: "100%",
+    backgroundColor: "#e6e6e6",
+    height: 70,
+    borderRadius: 35,
+    padding: "0 30px 0 100px",
+
+    // Focused input field affects icon prefix.
+    ":focus + span": {
+      color: colours.primary,
+      paddingLeft: metrics.padding.lg,
+    },
+  },
+
+  // Icon Prefix
+  "& span": {
+    fontSize: metrics.fontSize.xxl,
+    display: "flex",
+    alignItems: "center",
+    position: "absolute",
+    borderRadius: 25,
+    bottom: 0,
+    left: 0,
+    width: "100%",
+    height: "100%",
+    paddingLeft: metrics.padding.lg + 10,
+    pointerEvents: "none",
+    color: "#666666",
+    transition: "all 0.4s",
+  },
+});
+
+export const StyledSuggestion = styled.a({
+  display: "block",
+  margin: "0 20px",
+  padding: "5px 15px",
+  verticalAlign: "center",
+  height: 50,
+  lineHeight: "50px",
+  ":hover": {
+    backgroundColor: "rgba(82, 82, 82, .2)",
+  },
+});

--- a/src/routes/Search/Search.styled.ts
+++ b/src/routes/Search/Search.styled.ts
@@ -66,11 +66,11 @@ export const StyledSeachBarInput = styled.div({
 
 export const StyledSuggestion = styled.a({
   display: "block",
-  margin: "0 20px",
-  padding: "5px 15px",
+  margin: `${metrics.margin.none} ${metrics.margin.lg}px`,
+  padding: `${metrics.padding.tiny}px ${metrics.padding.md}px`,
   verticalAlign: "center",
-  height: 50,
-  lineHeight: "50px",
+  height: metrics.margin.xxl,
+  lineHeight: `${metrics.margin.xxl}px`,
   ":hover": {
     backgroundColor: "rgba(82, 82, 82, .2)",
   },

--- a/src/routes/Search/Search.tsx
+++ b/src/routes/Search/Search.tsx
@@ -67,6 +67,11 @@ class InternalSearch extends React.Component<
     try {
       const suggestions: PackageModel[] = await getSuggestions(searchQuery);
 
+      // If package with exact match, go to it.
+      if (suggestions.find((s) => s.package_name == searchQuery)) {
+        this.props.history.push(`/packages/${searchQuery}`);
+      }
+
       this.setState({
         isLoading: false,
         suggestions: suggestions,

--- a/src/routes/Search/Search.tsx
+++ b/src/routes/Search/Search.tsx
@@ -9,6 +9,7 @@ import { AiOutlineSearch } from "react-icons/ai";
 import { RouteComponentProps, withRouter } from "react-router-dom";
 import { getSuggestions } from "../../requests/services/search";
 import { Package as PackageModel } from "../../requests/payloads/package-payload";
+import metrics from "../../theme/metrics";
 
 /**
  * Props for the Search route.
@@ -107,6 +108,8 @@ class InternalSearch extends React.Component<
   }
 
   render() {
+    const { suggestions, isLoading } = this.state;
+
     return (
       <>
         <NavBar />
@@ -124,7 +127,16 @@ class InternalSearch extends React.Component<
               <AiOutlineSearch />
             </span>
           </StyledSeachBarInput>
-          {this.state.suggestions.map((pkg) => (
+          {suggestions.length == 0 && !isLoading && (
+            <h2
+              style={{
+                margin: metrics.margin.xxl,
+              }}
+            >
+              No suggestions
+            </h2>
+          )}
+          {suggestions.map((pkg) => (
             <StyledSuggestion
               href={"/#/packages/" + pkg.package_name}
               key={pkg.id}

--- a/src/routes/Search/Search.tsx
+++ b/src/routes/Search/Search.tsx
@@ -1,0 +1,136 @@
+import * as React from "react";
+import { NavBar } from "../../components/NavBar";
+import {
+  StyledContainer,
+  StyledSeachBarInput,
+  StyledSuggestion,
+} from "./Search.styled";
+import { AiOutlineSearch } from "react-icons/ai";
+import { RouteComponentProps, withRouter } from "react-router-dom";
+import { getSuggestions } from "../../requests/services/search";
+import { Package as PackageModel } from "../../requests/payloads/package-payload";
+
+/**
+ * Props for the Search route.
+ */
+export interface SearchProps {}
+
+/**
+ * State for the Search route.
+ */
+export interface SearchState {
+  /** Indicator of the current state; whether or not the page is loading. */
+  isLoading: boolean;
+
+  /** The search query for looking up the package. */
+  searchQuery: string;
+
+  /** The suggested packages for search query. */
+  suggestions: PackageModel[];
+}
+
+/**
+ * The Search page of the application.
+ * Displays the list of suggested packages that match the search query.
+ */
+class InternalSearch extends React.Component<
+  RouteComponentProps<SearchProps>,
+  SearchState
+> {
+  constructor(props: RouteComponentProps<SearchProps>, state: SearchState) {
+    super(props, state);
+
+    const windowUrl = this.props.location.search;
+    const query = new URLSearchParams(windowUrl).get("query") || "";
+    if (!query) this.props.history.push("/");
+
+    this.state = {
+      isLoading: true,
+      searchQuery: query,
+      suggestions: [],
+    };
+    this.handleSearchQueryChange = this.handleSearchQueryChange.bind(this);
+    this.handleSearch = this.handleSearch.bind(this);
+  }
+
+  componentDidMount(): void {
+    void this.retrieveSuggestions();
+  }
+
+  async retrieveSuggestions() {
+    this.setState({
+      isLoading: true,
+    });
+
+    const { searchQuery } = this.state;
+
+    try {
+      const suggestions: PackageModel[] = await getSuggestions(searchQuery);
+
+      this.setState({
+        isLoading: false,
+        suggestions: suggestions,
+      });
+    } catch (error) {
+      // TODO: display error?
+      console.log(error.toString());
+      this.setState({
+        isLoading: false,
+      });
+    }
+  }
+
+  /**
+   * Handle change in the search query input element.
+   * @param {React.ChangeEvent} e - change event object.
+   */
+  handleSearchQueryChange(e: React.ChangeEvent<HTMLInputElement>) {
+    this.setState({
+      searchQuery: e.target.value,
+    });
+  }
+
+  /**
+   * Handle search action for the package (key press callback).
+   * @param {React.KeyboardEvent} e - keyboard event object.
+   */
+  handleSearch(e: React.KeyboardEvent) {
+    if (e.key == "Enter") {
+      this.props.history.push(`/search?query=${this.state.searchQuery}`);
+      this.retrieveSuggestions();
+    }
+  }
+
+  render() {
+    return (
+      <>
+        <NavBar />
+        <StyledContainer>
+          <StyledSeachBarInput>
+            <input
+              type={"text"}
+              name={"search"}
+              placeholder={"Search package"}
+              value={this.state.searchQuery}
+              onChange={this.handleSearchQueryChange}
+              onKeyDown={this.handleSearch}
+            />
+            <span>
+              <AiOutlineSearch />
+            </span>
+          </StyledSeachBarInput>
+          {this.state.suggestions.map((pkg) => (
+            <StyledSuggestion
+              href={"/#/packages/" + pkg.package_name}
+              key={pkg.id}
+            >
+              {pkg.package_name}
+            </StyledSuggestion>
+          ))}
+        </StyledContainer>
+      </>
+    );
+  }
+}
+
+export const Search = withRouter(InternalSearch);

--- a/src/routes/Search/index.ts
+++ b/src/routes/Search/index.ts
@@ -1,0 +1,1 @@
+export * from "./Search";


### PR DESCRIPTION
Closes #43 

## Description
PR implements a search page that gives the user a list of suggested packages for a given query.

## Motivation and context
Previously, the user had to enter an exact match of the name for the wanted package, which is not user friendly. With search, users can throw in keywords and see what packages match them.