### PR TITLE
Allow nullable package's default version

### DIFF
--- a/src/requests/payloads/package-payload.ts
+++ b/src/requests/payloads/package-payload.ts
@@ -26,7 +26,7 @@ export const PACKAGE_SCHEMA = yup
     created_at: yup.date().max(new Date(Date.now())).nullable(),
 
     /** The latest version of the package. */
-    version: yup.string(),
+    version: yup.string().nullable(),
   })
   .required();
 
@@ -50,6 +50,7 @@ export const defaultPackage: Package = {
   project_name: "",
   repository: "",
   created_at: null,
+  version: null,
 };
 
 /**

--- a/src/routes/Package/Package.tsx
+++ b/src/routes/Package/Package.tsx
@@ -145,7 +145,7 @@ class InternalPackage extends React.Component<
     }
 
     // Redirect to the latest version by default.
-    if (verParam == undefined) {
+    if (verParam == undefined && pkg.version) {
       return <Redirect to={`/packages/${pkg.package_name}/${pkg.version}`} />;
     }
 
@@ -154,8 +154,13 @@ class InternalPackage extends React.Component<
         <NavBar />
         <StyledContainer>
           <StyledTitle>
-            <Link to={`/packages/${pkg.package_name}/${verParam}`}>
-              {pkg.project_name} {verParam}
+            <Link
+              to={
+                `/packages/${pkg.package_name}` +
+                (verParam === undefined ? "" : `/${verParam}`)
+              }
+            >
+              {pkg.project_name || pkg.package_name} {verParam}
             </Link>
             {namespace && (
               <>


### PR DESCRIPTION
Closes #46

## Description
There are packages in the system that have no available versions. PR allows to still navigate to these packages on the frontend side, but just the page will be mainly empty and useless for the user.
