### PR TITLE
Not Found Page (404)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { StyledAppContainer } from "./App.styled";
 import { Home } from "./routes/Home";
 import { Package } from "./routes/Package";
 import { Search } from "./routes/Search";
+import { NotFound } from "./routes/NotFound";
 
 export type AppProps = RouteComponentProps & {};
 
@@ -33,6 +34,7 @@ class InternalApp extends React.Component<AppProps, AppState> {
             key={location.key}
             component={Package}
           />
+          <Route component={NotFound} />
         </Switch>
       </StyledAppContainer>
     );

--- a/src/components/PackageTable/PackageTable.tsx
+++ b/src/components/PackageTable/PackageTable.tsx
@@ -88,10 +88,10 @@ class InternalPackageTable extends React.Component<
         data: dt,
       });
     } catch (error) {
-      // 404?
       this.setState({
         isLoading: false,
       });
+      this.props.history.push("/oops");
     }
   }
 

--- a/src/routes/Home/Home.tsx
+++ b/src/routes/Home/Home.tsx
@@ -9,6 +9,7 @@ import {
 } from "./Home.styled";
 import { AiOutlineSearch } from "react-icons/ai";
 import { RouteComponentProps, withRouter } from "react-router-dom";
+import { getPackage } from "../../requests/services/package";
 
 /**
  * Props for the Home route.
@@ -54,9 +55,17 @@ class InternalHome extends React.Component<
    * Handle search action for the package (key press callback).
    * @param {React.KeyboardEvent} e - keyboard event object.
    */
-  handleSearch(e: React.KeyboardEvent) {
-    if (e.key == "Enter")
-      this.props.history.push(`/search?query=${this.state.searchQuery}`);
+  async handleSearch(e: React.KeyboardEvent) {
+    if (e.key != "Enter") return;
+
+    const { searchQuery } = this.state;
+
+    try {
+      await getPackage(searchQuery);
+      this.props.history.push(`/packages/${searchQuery}`);
+    } catch (error) {
+      this.props.history.push(`/search?query=${searchQuery}`);
+    }
   }
 
   render() {

--- a/src/routes/NotFound/NotFound.styled.ts
+++ b/src/routes/NotFound/NotFound.styled.ts
@@ -1,0 +1,14 @@
+import styled from "@emotion/styled";
+import colours from "../../theme/colours";
+
+export const StyledContainer = styled.div({
+  width: "60%",
+  margin: "15px auto",
+  "& a": {
+    color: colours.primary,
+    textDecoration: "none",
+    ":hover": {
+      filter: "brightness(85%)",
+    },
+  },
+});

--- a/src/routes/NotFound/NotFound.tsx
+++ b/src/routes/NotFound/NotFound.tsx
@@ -1,0 +1,40 @@
+import * as React from "react";
+import { NavBar } from "../../components/NavBar";
+import { StyledContainer } from "./NotFound.styled";
+import { RouteComponentProps, withRouter } from "react-router-dom";
+
+/**
+ * Props for the NotFound route.
+ */
+export interface NotFoundProps {}
+
+/**
+ * State for the NotFound route.
+ */
+export interface NotFoundState {}
+
+/**
+ * The NotFound (404) page of the application.
+ */
+class InternalNotFound extends React.Component<
+  RouteComponentProps<NotFoundProps>,
+  NotFoundState
+> {
+  render() {
+    return (
+      <>
+        <NavBar />
+        <StyledContainer>
+          <h1>Page Not Found (404)</h1>
+          <p>
+            Looks like you have followed a broken link or entered a URL that
+            does not exist on the site.
+          </p>
+          <a href={"/"}>&larr; Back to home page</a>
+        </StyledContainer>
+      </>
+    );
+  }
+}
+
+export const NotFound = withRouter(InternalNotFound);

--- a/src/routes/NotFound/index.ts
+++ b/src/routes/NotFound/index.ts
@@ -1,0 +1,1 @@
+export * from "./NotFound";

--- a/src/routes/Package/Package.tsx
+++ b/src/routes/Package/Package.tsx
@@ -90,11 +90,10 @@ class InternalPackage extends React.Component<
         pkg: pkga,
       });
     } catch (error) {
-      // TODO: display error?
-      console.log(error.toString());
       this.setState({
         isLoading: false,
       });
+      this.props.history.push("/oops");
     }
   }
 

--- a/src/routes/Search/Search.tsx
+++ b/src/routes/Search/Search.tsx
@@ -68,11 +68,6 @@ class InternalSearch extends React.Component<
     try {
       const suggestions: PackageModel[] = await getSuggestions(searchQuery);
 
-      // If package with exact match, go to it.
-      if (suggestions.find((s) => s.package_name == searchQuery)) {
-        this.props.history.push(`/packages/${searchQuery}`);
-      }
-
       this.setState({
         isLoading: false,
         suggestions: suggestions,


### PR DESCRIPTION
Closes #45 

## Description
PR implements a `404` page. 

## Task list  

Show `404` if:
- [x] URL is incorrect (e.g., `/awdwad`);
- [x] Package not found in `/packages/{packageName}`, where `packageName` is incorrect;
- [x] Package Table didn't find entities (e.g., `/packages/{packageName}/{namespace}`, where `namespace` is incorrect; requires [fasten-project/fasten#213](https://github.com/fasten-project/fasten/issues/213));
- [x] **Extra:** avoid redirection to Search page from Home page if the search query has an exact match in the system. 
## Additional context
[fasten-project/fasten#213](https://github.com/fasten-project/fasten/issues/213)