### PR TITLE
Removed # from base url

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,7 +8,7 @@ import "./index.css";
 
 ReactDOM.render(
   <React.StrictMode>
-    <HashRouter basename={"/"}>
+    <BrowserRouter>
       <App />
     </HashRouter>
   </React.StrictMode>,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { App } from "./App";
 import * as serviceWorker from "./serviceWorker";
-import { HashRouter } from "react-router-dom";
+import { BrowserRouter } from "react-router-dom";
 
 import "./index.css";
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,7 +10,7 @@ ReactDOM.render(
   <React.StrictMode>
     <BrowserRouter>
       <App />
-    </HashRouter>
+    </BrowserRouter>
   </React.StrictMode>,
   document.getElementById("app")
 );

--- a/src/routes/Home/Home.tsx
+++ b/src/routes/Home/Home.tsx
@@ -85,7 +85,7 @@ class InternalHome extends React.Component<
 
           <StyledSubtitle>
             Example:{" "}
-            <a href={"/#/packages/jboss:jbossmq-client/3.2.3"}>
+            <a href={"/packages/jboss:jbossmq-client/3.2.3"}>
               jboss:jbossmq-client
             </a>
           </StyledSubtitle>


### PR DESCRIPTION
Closes #41 

## Description
There is a problem with deploying React App to Github Pages. The root page of a deployed to Github Pages application is, for example in our case, fasten-project.github.io/fasten-web. However, React doesn't like it. It wants to see an empty path (without fasten-web as a root page). So removed the # from base url.

## Motivation and context
If it fixes an open issue, please link to the issue here.
This PR will resolve the issue #41 .