### PR TITLE
Revert "Removed # from base url"

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,15 +2,15 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { App } from "./App";
 import * as serviceWorker from "./serviceWorker";
-import { BrowserRouter } from "react-router-dom";
+import { HashRouter } from "react-router-dom";
 
 import "./index.css";
 
 ReactDOM.render(
   <React.StrictMode>
-    <BrowserRouter>
+    <HashRouter basename={"/"}>
       <App />
-    </BrowserRouter>
+    </HashRouter>
   </React.StrictMode>,
   document.getElementById("app")
 );

--- a/src/routes/Home/Home.tsx
+++ b/src/routes/Home/Home.tsx
@@ -94,7 +94,7 @@ class InternalHome extends React.Component<
 
           <StyledSubtitle>
             Example:{" "}
-            <a href={"/packages/jboss:jbossmq-client/3.2.3"}>
+            <a href={"/#/packages/jboss:jbossmq-client/3.2.3"}>
               jboss:jbossmq-client
             </a>
           </StyledSubtitle>


### PR DESCRIPTION
Reverts fasten-project/fasten-web#49

So far `HashRouter` is seen to be the only viable router for the application. Although `BrowserRouter` now invokes the homepage, any attempt to open the page via sharing the link is impossible due to its nature.

The problem is that Github Pages does not support SPA natively. Thus, `BrowserRouter` fails. With `HashRouter`, undesired `#` is a necessity.

There is a [workaround](https://github.com/rafgraph/spa-github-pages) for `BrowserRouter`, but it is questionable.