### PR TITLE
Readable callables

### DIFF
--- a/src/components/Package/Package.tsx
+++ b/src/components/Package/Package.tsx
@@ -25,19 +25,6 @@ class InternalPackage extends React.Component<PackageProps, PackageState> {
   render() {
     const tabs: Tab[] = [
       {
-        label: "Versions",
-        body: () => {
-          return (
-            <PackageTable
-              kind={"VERSIONS"}
-              pkg={this.props.pkg}
-              pkgVersion={this.props.pkgVer}
-              fetchEntities={() => getPackageVersions(this.props.pkg)}
-            />
-          );
-        },
-      },
-      {
         label: "Modules",
         body: () => {
           return (
@@ -59,6 +46,19 @@ class InternalPackage extends React.Component<PackageProps, PackageState> {
             <VulnerabilitiesTable
               pkg={this.props.pkg}
               pkgVersion={this.props.pkgVer}
+            />
+          );
+        },
+      },
+      {
+        label: "Versions",
+        body: () => {
+          return (
+            <PackageTable
+              kind={"VERSIONS"}
+              pkg={this.props.pkg}
+              pkgVersion={this.props.pkgVer}
+              fetchEntities={() => getPackageVersions(this.props.pkg)}
             />
           );
         },

--- a/src/components/PackageTable/PackageTable.tsx
+++ b/src/components/PackageTable/PackageTable.tsx
@@ -161,12 +161,13 @@ class InternalPackageTable extends React.Component<
     const { pkg, pkgVersion, namespace } = this.props;
 
     const encodedNamespace = encodeURIComponent(namespace || "...");
-    const encodedFastenURI = encodeURIComponent(entity.fasten_uri);
+    const encodedMethodArgs = encodeURIComponent(entity.methodArgs || "");
 
     return (
       <StyledVersionRow key={`callable_${entity.id}`}>
         <Link
-          to={`/packages/${pkg}/${pkgVersion}/${encodedNamespace}/${encodedFastenURI}`}
+          // TODO: will need to do something with callable path; it won't work this way.
+          to={`/packages/${pkg}/${pkgVersion}/${encodedNamespace}/${entity.methodName}(${encodedMethodArgs})`}
         >
           {(entity.methodName &&
             entity.methodArgs != null &&

--- a/src/components/PackageTable/PackageTable.tsx
+++ b/src/components/PackageTable/PackageTable.tsx
@@ -168,7 +168,10 @@ class InternalPackageTable extends React.Component<
         <Link
           to={`/packages/${pkg}/${pkgVersion}/${encodedNamespace}/${encodedFastenURI}`}
         >
-          {decodeURIComponent(entity.fasten_uri)}
+          {(entity.method_name &&
+            entity.method_args &&
+            `${entity.method_name}(${entity.method_args})`) ||
+            entity.fasten_uri}
         </Link>
       </StyledVersionRow>
     );

--- a/src/components/PackageTable/PackageTable.tsx
+++ b/src/components/PackageTable/PackageTable.tsx
@@ -168,9 +168,9 @@ class InternalPackageTable extends React.Component<
         <Link
           to={`/packages/${pkg}/${pkgVersion}/${encodedNamespace}/${encodedFastenURI}`}
         >
-          {(entity.method_name &&
-            entity.method_args &&
-            `${entity.method_name}(${entity.method_args})`) ||
+          {(entity.methodName &&
+            entity.methodArgs &&
+            `${entity.methodName}(${entity.methodArgs})`) ||
             entity.fasten_uri}
         </Link>
       </StyledVersionRow>

--- a/src/components/PackageTable/PackageTable.tsx
+++ b/src/components/PackageTable/PackageTable.tsx
@@ -169,7 +169,7 @@ class InternalPackageTable extends React.Component<
           to={`/packages/${pkg}/${pkgVersion}/${encodedNamespace}/${encodedFastenURI}`}
         >
           {(entity.methodName &&
-            entity.methodArgs &&
+            entity.methodArgs != null &&
             `${entity.methodName}(${entity.methodArgs})`) ||
             entity.fasten_uri}
         </Link>

--- a/src/requests/payloads/package-callable-payload.ts
+++ b/src/requests/payloads/package-callable-payload.ts
@@ -17,10 +17,10 @@ export const PACKAGE_CALLABLE_SCHEMA = yup
     fasten_uri: yup.string().required(),
 
     /** User-friendly, formatted string of method name. */
-    method_name: yup.string().nullable(),
+    methodName: yup.string().nullable(),
 
     /** User-friendly, formatted string of method arguments. */
-    method_args: yup.string().nullable(),
+    methodArgs: yup.string().nullable(),
 
     /** Is the callable internal within the package? */
     is_internal_call: yup.boolean().required(),
@@ -63,8 +63,8 @@ export const defaultCallable: Callable = {
   id: 0,
   module_id: 0,
   fasten_uri: "",
-  method_name: "",
-  method_args: "",
+  methodName: "",
+  methodArgs: "",
   is_internal_call: true,
   line_start: 0,
   line_end: 0,

--- a/src/requests/payloads/package-callable-payload.ts
+++ b/src/requests/payloads/package-callable-payload.ts
@@ -16,6 +16,12 @@ export const PACKAGE_CALLABLE_SCHEMA = yup
     /** The URI in the FASTEN system. */
     fasten_uri: yup.string().required(),
 
+    /** User-friendly, formatted string of method name. */
+    method_name: yup.string().nullable(),
+
+    /** User-friendly, formatted string of method arguments. */
+    method_args: yup.string().nullable(),
+
     /** Is the callable internal within the package? */
     is_internal_call: yup.boolean().required(),
 
@@ -57,6 +63,8 @@ export const defaultCallable: Callable = {
   id: 0,
   module_id: 0,
   fasten_uri: "",
+  method_name: "",
+  method_args: "",
   is_internal_call: true,
   line_start: 0,
   line_end: 0,


### PR DESCRIPTION
Closes #51

## Description
The PR utilizes the formatted response for callables. Instead of `fasten uri`, it displays method signature.

## Motivation and context
Previously, callables were described by their `fasten uris`, but they are very long and hardly-readable, thus inconvenient for users.

## Additional context
[fasten-project/fasten#218](https://github.com/fasten-project/fasten/issues/218)
[fasten-project/fasten#238](https://github.com/fasten-project/fasten/issues/238)
