### PR TITLE
Quickfix: Make line start and end in callable schema nullable

### DIFF
--- a/src/requests/payloads/package-callable-payload.ts
+++ b/src/requests/payloads/package-callable-payload.ts
@@ -26,10 +26,10 @@ export const PACKAGE_CALLABLE_SCHEMA = yup
     is_internal_call: yup.boolean().required(),
 
     /** The start line of the callable. */
-    line_start: yup.number().integer().required(),
+    line_start: yup.number().integer().nullable(),
 
     /** The end line of the callable. */
-    line_end: yup.number().integer().required(),
+    line_end: yup.number().integer().nullable(),
 
     /** The date when the callable was published. */
     created_at: yup.date().max(new Date(Date.now())).nullable(),


### PR DESCRIPTION
## Description
The PR allows keys `line_start` and `line_end` to be nullable in the callable payload schema.

## Motivation and context
Some callables in the modules may be such; for example, in module `/org.jboss.mq.il/ClientIL` in package `jboss:jbossmq-client$3.2.3`.