### PR TITLE
Add list of examples on homepage

### DIFF
--- a/src/components/HomeExamples/HomeExampleBlock.tsx
+++ b/src/components/HomeExamples/HomeExampleBlock.tsx
@@ -1,0 +1,38 @@
+import { RouteComponentProps, withRouter } from "react-router";
+import * as React from "react";
+import { StyledExampleBlockContainer } from "./HomeExamples.styled";
+
+export interface HomeExampleBlockProps extends RouteComponentProps {
+  /** Package name of the example.  **/
+  pkgName: string;
+
+  /** Package url of the example.  **/
+  pkgUrl: string;
+
+  /** Package description of the example.  **/
+  pkgDesc: string;
+}
+
+export interface HomeExampleBlockState {}
+
+/**
+ * The component that renders a single example block.
+ */
+class InternalHomeExampleBlock extends React.Component<
+  HomeExampleBlockProps,
+  HomeExampleBlockState
+> {
+  render() {
+    const { pkgName, pkgDesc, pkgUrl } = this.props;
+    return (
+      <StyledExampleBlockContainer>
+        <a href={pkgUrl}>
+          <h4>{pkgName}</h4>
+        </a>
+        <span>{pkgDesc}</span>
+      </StyledExampleBlockContainer>
+    );
+  }
+}
+
+export const HomeExampleBlock = withRouter(InternalHomeExampleBlock);

--- a/src/components/HomeExamples/HomeExamples.styled.tsx
+++ b/src/components/HomeExamples/HomeExamples.styled.tsx
@@ -1,0 +1,35 @@
+import styled from "@emotion/styled";
+
+/**
+ * The styled component for the container that holds the example blocks on the homepage.
+ */
+export const StyledHomeExamplesContainer = styled.div({
+  display: "flex",
+  flexDirection: "row",
+  alignItems: "center",
+  justifyContent: "center",
+  margin: "5% 0",
+
+  "& h4": {
+    margin: "0 0 10px",
+  },
+});
+
+/**
+ * The styled component for the container of the example block itself on the homepage.
+ */
+export const StyledExampleBlockContainer = styled.div({
+  display: "inline-block",
+  width: "15%",
+  height: "150px",
+  margin: "0 20px",
+  padding: "20px",
+
+  lineHeight: "1.5",
+  textAlign: "left",
+  overflow: "scroll",
+
+  border: "1px solid rgba(200, 200, 200, .7)",
+  boxShadow: "5px 5px 10px grey",
+  borderRadius: 10,
+});

--- a/src/components/HomeExamples/HomeExamples.tsx
+++ b/src/components/HomeExamples/HomeExamples.tsx
@@ -1,0 +1,56 @@
+import * as React from "react";
+import { HomeExampleBlock } from "./HomeExampleBlock";
+import { StyledHomeExamplesContainer } from "./HomeExamples.styled";
+
+export interface HomeExamplesProps {}
+
+export interface HomeExamplesState {}
+
+/**
+ * The component that renders the horizontal list of example packages at the Home Page.
+ */
+export class HomeExamples extends React.Component<
+  HomeExamplesProps,
+  HomeExamplesState
+> {
+  render() {
+    return (
+      <StyledHomeExamplesContainer>
+        <HomeExampleBlock
+          pkgName={"Junit"}
+          pkgDesc={
+            "The programmer-friendly testing framework for Java and the JVM."
+          }
+          pkgUrl={"/#/packages/junit:junit"}
+        />
+        <HomeExampleBlock
+          pkgName={"JBossMQ Client"}
+          pkgDesc={
+            "Implementation of the Java Message Service API part of the J2EE specification."
+          }
+          pkgUrl={"/#/packages/jboss:jbossmq-client/3.2.3"}
+        />
+        <HomeExampleBlock
+          pkgName={"Mockito Core"}
+          pkgDesc={"Tasty mocking framework for unit tests in Java."}
+          pkgUrl={"/#/packages/org.mockito:mockito-core/1.10.18"}
+        />
+        <HomeExampleBlock
+          pkgName={"SLF4J API"}
+          pkgDesc={"The Simple Logging Facade for Java."}
+          pkgUrl={"/#/packages/org.slf4j:slf4j-api/1.1.0"}
+        />
+        <HomeExampleBlock
+          pkgName={"Scala Library"}
+          pkgDesc={"Standard library for the Scala Programming Language."}
+          pkgUrl={"/#/packages/org.scala-lang:scala-library/2.10.0"}
+        />
+        <HomeExampleBlock
+          pkgName={"Jackson Databind"}
+          pkgDesc={"General data-binding functionality for Jackson."}
+          pkgUrl={"/#/packages/com.fasterxml.jackson.core:jackson-databind"}
+        />
+      </StyledHomeExamplesContainer>
+    );
+  }
+}

--- a/src/components/HomeExamples/index.ts
+++ b/src/components/HomeExamples/index.ts
@@ -1,0 +1,1 @@
+export * from "./HomeExamples";

--- a/src/routes/Home/Home.styled.ts
+++ b/src/routes/Home/Home.styled.ts
@@ -3,7 +3,7 @@ import metrics from "../../theme/metrics";
 import colours from "../../theme/colours";
 
 export const StyledContainer = styled.div({
-  marginTop: "12%",
+  marginTop: "5%",
   width: "100%",
   "& a": {
     color: colours.primary,
@@ -18,10 +18,6 @@ export const StyledTitle = styled.p({
   width: "45%",
   margin: "auto",
   fontSize: metrics.fontSize.xl,
-  textAlign: "center",
-});
-
-export const StyledSubtitle = styled.p({
   textAlign: "center",
 });
 

--- a/src/routes/Home/Home.tsx
+++ b/src/routes/Home/Home.tsx
@@ -4,12 +4,12 @@ import {
   StyledContainer,
   StyledDisclaimer,
   StyledSeachBarInput,
-  StyledSubtitle,
   StyledTitle,
 } from "./Home.styled";
 import { AiOutlineSearch } from "react-icons/ai";
 import { RouteComponentProps, withRouter } from "react-router-dom";
 import { getPackage } from "../../requests/services/package";
+import { HomeExamples } from "../../components/HomeExamples";
 
 /**
  * Props for the Home route.
@@ -92,12 +92,7 @@ class InternalHome extends React.Component<
             </span>
           </StyledSeachBarInput>
 
-          <StyledSubtitle>
-            Example:{" "}
-            <a href={"/#/packages/jboss:jbossmq-client/3.2.3"}>
-              jboss:jbossmq-client
-            </a>
-          </StyledSubtitle>
+          <HomeExamples />
 
           <StyledDisclaimer>
             <p>


### PR DESCRIPTION
Closes #59 

## Description
The PR adds on the homepage a horizontal list of 6 popular example packages to check.

## Motivation and context
The newcomers don't know what they can expect from the platform. Thus, it would be easier for them to have a set of examples they can check out.