### PR TITLE
Revert "Change check for method args"

### DIFF
--- a/src/components/PackageTable/PackageTable.tsx
+++ b/src/components/PackageTable/PackageTable.tsx
@@ -161,17 +161,17 @@ class InternalPackageTable extends React.Component<
     const { pkg, pkgVersion, namespace } = this.props;
 
     const encodedNamespace = encodeURIComponent(namespace || "...");
-    const encodedMethodArgs = encodeURIComponent(entity.methodArgs || "");
+    const encodedMethodArgs = encodeURIComponent(entity.method_args || "");
 
     return (
       <StyledVersionRow key={`callable_${entity.id}`}>
         <Link
           // TODO: will need to do something with callable path; it won't work this way.
-          to={`/packages/${pkg}/${pkgVersion}/${encodedNamespace}/${entity.methodName}(${encodedMethodArgs})`}
+          to={`/packages/${pkg}/${pkgVersion}/${encodedNamespace}/${entity.method_name}(${encodedMethodArgs})`}
         >
-          {(entity.methodName &&
-            entity.methodArgs &&
-            `${entity.methodName}(${entity.methodArgs})`) ||
+          {(entity.method_name &&
+            entity.method_args &&
+            `${entity.method_name}(${entity.method_args})`) ||
             entity.fasten_uri}
         </Link>
       </StyledVersionRow>

--- a/src/components/PackageTable/PackageTable.tsx
+++ b/src/components/PackageTable/PackageTable.tsx
@@ -170,7 +170,7 @@ class InternalPackageTable extends React.Component<
           to={`/packages/${pkg}/${pkgVersion}/${encodedNamespace}/${entity.methodName}(${encodedMethodArgs})`}
         >
           {(entity.methodName &&
-            entity.methodArgs != null &&
+            entity.methodArgs &&
             `${entity.methodName}(${entity.methodArgs})`) ||
             entity.fasten_uri}
         </Link>

--- a/src/requests/payloads/package-callable-payload.ts
+++ b/src/requests/payloads/package-callable-payload.ts
@@ -17,10 +17,10 @@ export const PACKAGE_CALLABLE_SCHEMA = yup
     fasten_uri: yup.string().required(),
 
     /** User-friendly, formatted string of method name. */
-    methodName: yup.string().nullable(),
+    method_name: yup.string().nullable(),
 
     /** User-friendly, formatted string of method arguments. */
-    methodArgs: yup.string().nullable(),
+    method_args: yup.string().nullable(),
 
     /** Is the callable internal within the package? */
     is_internal_call: yup.boolean().required(),
@@ -63,8 +63,8 @@ export const defaultCallable: Callable = {
   id: 0,
   module_id: 0,
   fasten_uri: "",
-  methodName: "",
-  methodArgs: "",
+  method_name: "",
+  method_args: "",
   is_internal_call: true,
   line_start: 0,
   line_end: 0,


### PR DESCRIPTION
This reverts commit 86f5d71a68a8da006c5ea33045bd2e6849baa0bc.

## Description
Rename keys for method signature in module callables endpoint.

## Motivation and context
Inconsistency with other namings.

## Additional context
https://github.com/fasten-project/fasten/issues/238
