### PR TITLE
Add temporary fetching of direct vulnerable deps

### DIFF
--- a/src/components/Package/VulnerabitiesTable/VulnerabilitiesTable.tsx
+++ b/src/components/Package/VulnerabitiesTable/VulnerabilitiesTable.tsx
@@ -27,7 +27,7 @@ export interface VulnerabilitiesTableState {
   isLoading: boolean;
 
   /** The list of entities included in the table. */
-  data: Vulnerability[];
+  data: Vulnerability;
 }
 
 class InternalVulnerabilitiesTable extends React.Component<
@@ -42,7 +42,7 @@ class InternalVulnerabilitiesTable extends React.Component<
 
     this.state = {
       isLoading: true,
-      data: [],
+      data: {},
     };
   }
 
@@ -64,7 +64,7 @@ class InternalVulnerabilitiesTable extends React.Component<
 
       this.setState({
         isLoading: false,
-        data: [vulners],
+        data: vulners,
       });
     } catch (error) {
       this.setState({
@@ -79,24 +79,23 @@ class InternalVulnerabilitiesTable extends React.Component<
    */
   renderRow = (entity: any): React.ReactNode => {
     return (
-      <StyledVersionRow key={`vulnerability_${entity.id}`}>
-        {entity.path &&
-          entity.path.map((step: any, index: number) => {
-            return (
-              <>
-                {index > 0 && <br />}
-                {index > 0 && (
-                  <span style={{ marginLeft: 50 }}>
-                    <BsArrowRight />{" "}
-                  </span>
-                )}
-                {/* TODO: enhance details, so the vulnerability links to a specific callable. */}
-                <Link to={`/packages/${step.package_name}/${step.version}`}>
-                  {step.package_name}/{step.version}
-                </Link>
-              </>
-            );
-          })}
+      <StyledVersionRow key={`vulnerability_${entity[0].id}`}>
+        {entity.map((step: any, index: number) => {
+          return (
+            <>
+              {index > 0 && <br />}
+              {index > 0 && (
+                <span style={{ marginLeft: 50 }}>
+                  <BsArrowRight />{" "}
+                </span>
+              )}
+              {/* TODO: enhance details, so the vulnerability links to a specific callable. */}
+              <Link to={`/packages/${step.package_name}/${step.version}`}>
+                {step.package_name}/{step.version}
+              </Link>
+            </>
+          );
+        })}
       </StyledVersionRow>
     );
   };
@@ -110,10 +109,10 @@ class InternalVulnerabilitiesTable extends React.Component<
       <StyledContainer>
         <h3>Vulnerabilities</h3>
         <hr />
-        {this.state.data.length == 0 && (
+        {this.state.data.vulnerabilities?.length == 0 && (
           <h2>No vulnerabilities found for this package!</h2>
         )}
-        {this.state.data.map(this.renderRow)}
+        {this.state.data.vulnerabilities?.map(this.renderRow)}
       </StyledContainer>
     );
   }

--- a/src/components/Package/VulnerabitiesTable/VulnerabilitiesTable.tsx
+++ b/src/components/Package/VulnerabitiesTable/VulnerabilitiesTable.tsx
@@ -91,7 +91,8 @@ class InternalVulnerabilitiesTable extends React.Component<
               )}
               {/* TODO: enhance details, so the vulnerability links to a specific callable. */}
               <Link to={`/packages/${step.package_name}/${step.version}`}>
-                {step.package_name}/{step.version}
+                {step.package_name}/{step.version}/{step.class_name}.
+                {step.method_name}
               </Link>
             </>
           );

--- a/src/requests/payloads/package-vulnerabilities-payload.ts
+++ b/src/requests/payloads/package-vulnerabilities-payload.ts
@@ -8,17 +8,19 @@ export const PACKAGE_VULNERABILITY_SCHEMA = yup
   .object()
   .shape({
     // vulnerability: yup.string().required(),
-    path: array().of(
-      yup
-        .object()
-        .shape({
-          id: yup.number().positive().required(),
-          package_name: yup.string().required(),
-          version: yup.string().required(),
-          class_name: yup.string().required(),
-          method_name: yup.string().required(),
-        })
-        .required()
+    vulnerabilities: array().of(
+      array().of(
+        yup
+          .object()
+          .shape({
+            id: yup.number().positive().required(),
+            package_name: yup.string().required(),
+            version: yup.string().required(),
+            class_name: yup.string().required(),
+            method_name: yup.string().required(),
+          })
+          .required()
+      )
     ),
   })
   .required();
@@ -43,14 +45,16 @@ export type VulnerabilitiesResponsePayload = Vulnerability;
  */
 export const defaultVulnerability: Vulnerability = {
   // vulnerability: "https://demo.fasten-project.eu/",
-  path: [
-    {
-      id: 0,
-      package_name: "",
-      version: "",
-      class_name: "",
-      method_name: "",
-    },
+  vulnerabilities: [
+    [
+      {
+        id: 0,
+        package_name: "",
+        version: "",
+        class_name: "",
+        method_name: "",
+      },
+    ],
   ],
 };
 


### PR DESCRIPTION
## Description
The PR implements the latest version of Fasten API of Vulnerable path cacher.

Currently, it is available only for vulnerabilities between direct dependencies.

In the nearest future, major changes are expected.