### PR TITLE
Prettify rendering of Fasten URIs

### DIFF
--- a/src/components/PackageTable/PackageTable.tsx
+++ b/src/components/PackageTable/PackageTable.tsx
@@ -5,6 +5,7 @@ import { Module } from "../../requests/payloads/package-module-payload";
 import { Callable } from "../../requests/payloads/package-callable-payload";
 import { PackageVersion } from "../../requests/payloads/package-versions-payload";
 import { FastenUri } from "../../requests/payloads/fasten-uri-payload";
+import config from "../../config";
 
 type VersionsTableData = {
   kind: "VERSIONS";
@@ -180,33 +181,48 @@ class InternalPackageTable extends React.Component<
         ({" "}
         {entity.fasten_uri.args.map((uri) => (
           <>
-            <a
-              key={uri.rawEntity}
-              href={
-                `#/packages/${pkg}/${pkgVersion}/` +
-                encodeURIComponent(
-                  `/${entity.fasten_uri.rawNamespace}/${uri.className}`
-                )
-              }
-            >
-              {uri.className},
-            </a>{" "}
+            {this.renderType(
+              pkg,
+              pkgVersion,
+              entity.fasten_uri.rawNamespace,
+              uri
+            )}
+            {", "}
           </>
         ))}{" "}
         ){" : "}
-        <a
-          href={
-            `#/packages/${pkg}/${pkgVersion}/` +
-            encodeURIComponent(
-              `/${entity.fasten_uri.rawNamespace}/${entity.fasten_uri.returnType.className}`
-            )
-          }
-        >
-          {entity.fasten_uri.returnType.className}
-        </a>
+        {this.renderType(
+          pkg,
+          pkgVersion,
+          entity.fasten_uri.rawNamespace,
+          entity.fasten_uri.returnType
+        )}
       </StyledVersionRow>
     );
   };
+
+  renderType(
+    pkg: string,
+    pkgVersion: string,
+    rawNamespace?: string,
+    type?: any
+  ): React.ReactNode {
+    if (config.ignoreNamespaceLinkage.includes(type.rawNamespace)) {
+      return <>{type.className}</>;
+    } else {
+      return (
+        <a
+          key={type.rawEntity}
+          href={
+            `#/packages/${pkg}/${pkgVersion}/` +
+            encodeURIComponent(`/${rawNamespace}/${type.className}`)
+          }
+        >
+          {type.className}
+        </a>
+      );
+    }
+  }
 
   renderRows(): React.ReactNode {
     if (this.state.data?.entities.length == 0) {

--- a/src/components/PackageTable/PackageTable.tsx
+++ b/src/components/PackageTable/PackageTable.tsx
@@ -215,7 +215,9 @@ class InternalPackageTable extends React.Component<
           key={type.rawEntity}
           href={
             `#/packages/${pkg}/${pkgVersion}/` +
-            encodeURIComponent(`/${rawNamespace}/${type.className}`)
+            encodeURIComponent(
+              `/${type.rawNamespace || rawNamespace}/${type.className}`
+            )
           }
         >
           {type.className}

--- a/src/components/PackageTable/PackageTable.tsx
+++ b/src/components/PackageTable/PackageTable.tsx
@@ -4,6 +4,7 @@ import { StyledContainer, StyledVersionRow } from "./PackageTable.styled";
 import { Module } from "../../requests/payloads/package-module-payload";
 import { Callable } from "../../requests/payloads/package-callable-payload";
 import { PackageVersion } from "../../requests/payloads/package-versions-payload";
+import { FastenUri } from "../../requests/payloads/fasten-uri-payload";
 
 type VersionsTableData = {
   kind: "VERSIONS";
@@ -156,24 +157,53 @@ class InternalPackageTable extends React.Component<
 
   /**
    * Renders the package callable entity.
-   * @param entity is {@link Callable} to render.
+   * @param entity is {@link FastenUri} to render.
    */
   renderCallableRow = (entity: Callable): React.ReactNode => {
     const { pkg, pkgVersion, namespace } = this.props;
 
-    const encodedNamespace = encodeURIComponent(namespace || "...");
-    const encodedMethodArgs = encodeURIComponent(entity.method_args || "");
+    const encodedNamespace = encodeURIComponent(
+      entity.fasten_uri.className || "..."
+    );
+    const encodedMethodName = encodeURIComponent(
+      entity.fasten_uri.functionOrAttributeName || "..."
+    );
 
     return (
       <StyledVersionRow key={`callable_${entity.id}`}>
         <Link
           // TODO: will need to do something with callable path; it won't work this way.
-          to={`/packages/${pkg}/${pkgVersion}/${encodedNamespace}/${entity.method_name}(${encodedMethodArgs})`}
+          to={`/packages/${pkg}/${pkgVersion}/${encodedNamespace}/${encodedMethodName}`}
         >
-          {(entity.method_name &&
-            `${entity.method_name}(${entity.method_args || ""})`) ||
-            entity.fasten_uri}
+          {entity.fasten_uri.functionOrAttributeName}
         </Link>
+        ({" "}
+        {entity.fasten_uri.args.map((uri) => (
+          <>
+            <a
+              key={uri.rawEntity}
+              href={
+                `#/packages/${pkg}/${pkgVersion}/` +
+                encodeURIComponent(
+                  `/${entity.fasten_uri.rawNamespace}/${uri.className}`
+                )
+              }
+            >
+              {uri.className},
+            </a>{" "}
+          </>
+        ))}{" "}
+        ){" -> "}
+        <a
+          href={
+            `#/packages/${pkg}/${pkgVersion}/` +
+            encodeURIComponent(
+              `/${entity.fasten_uri.rawNamespace}/${entity.fasten_uri.returnType.className}`
+            )
+          }
+        >
+          {entity.fasten_uri.returnType.className}
+        </a>
       </StyledVersionRow>
     );
   };

--- a/src/components/PackageTable/PackageTable.tsx
+++ b/src/components/PackageTable/PackageTable.tsx
@@ -171,8 +171,7 @@ class InternalPackageTable extends React.Component<
           to={`/packages/${pkg}/${pkgVersion}/${encodedNamespace}/${entity.method_name}(${encodedMethodArgs})`}
         >
           {(entity.method_name &&
-            entity.method_args &&
-            `${entity.method_name}(${entity.method_args})`) ||
+            `${entity.method_name}(${entity.method_args || ""})`) ||
             entity.fasten_uri}
         </Link>
       </StyledVersionRow>

--- a/src/components/PackageTable/PackageTable.tsx
+++ b/src/components/PackageTable/PackageTable.tsx
@@ -193,7 +193,7 @@ class InternalPackageTable extends React.Component<
             </a>{" "}
           </>
         ))}{" "}
-        ){" -> "}
+        ){" : "}
         <a
           href={
             `#/packages/${pkg}/${pkgVersion}/` +

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,10 +1,10 @@
 const config = {
-  api: "http://127.0.0.1:8080",
-  // api: "https://api.fasten-project.eu",
-  apiSuffix: "",
+  // api: "http://127.0.0.1:8080",
+  api: "https://api.fasten-project.eu",
+  apiSuffix: "api",
   git: "https://github.com/fasten-project/",
-  webpage: "http://fasten-project.eu/",
-  ignoreNamespaceLinkage: ["java.lang"],
+  webpage: "https://fasten-project.eu/",
+  ignoreNamespaceLinkage: ["java.lang", "java.util"],
 };
 
 export default config;

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,9 +1,10 @@
 const config = {
-  // api: "http://127.0.0.1:8080",
-  api: "https://api.fasten-project.eu",
-  apiSuffix: "api",
+  api: "http://127.0.0.1:8080",
+  // api: "https://api.fasten-project.eu",
+  apiSuffix: "",
   git: "https://github.com/fasten-project/",
   webpage: "http://fasten-project.eu/",
+  ignoreNamespaceLinkage: ["java.lang"],
 };
 
 export default config;

--- a/src/requests/payloads/fasten-uri-payload.ts
+++ b/src/requests/payloads/fasten-uri-payload.ts
@@ -1,0 +1,65 @@
+import * as yup from "yup";
+
+const short_uri_schema = yup
+  .object()
+  .shape({
+    className: yup.string().required(),
+    uri: yup.string().required(),
+    rawEntity: yup.string().required(),
+    rawNamespace: yup.string().optional(),
+  })
+  .required();
+
+/**
+ * Validation schema for {@link FastenUri}.
+ */
+export const FASTEN_URI_SCHEMA = yup
+  .object()
+  .shape({
+    /** Full Fasten URI for the entity. */
+    uri: yup.string().required(),
+
+    /** User-friendly, formatted string of the class name. */
+    className: yup.string().nullable(),
+
+    /** User-friendly, formatted string of the method name. */
+    functionOrAttributeName: yup.string().nullable(),
+
+    /** User-friendly, formatted string of method's arguments. */
+    args: yup.array().of(short_uri_schema).required(),
+
+    /** User-friendly, formatted string of method's return type. */
+    returnType: short_uri_schema,
+
+    /** Raw string identifying forge of the entity. */
+    rawForge: yup.string().nullable(),
+
+    /** Raw string identifying product of the entity. */
+    rawProduct: yup.string().nullable(),
+
+    /** Raw string identifying version of the entity. */
+    rawVersion: yup.string().nullable(),
+
+    /** Raw string identifying namespace of the entity. */
+    rawNamespace: yup.string().nullable(),
+
+    /** Raw string identifying whole entity. */
+    rawEntity: yup.string().nullable(),
+  })
+  .required();
+
+/**
+ * The type of the Callable instance generated from yup schema {@link PACKAGE_MODULE_SCHEMA}.
+ */
+export type FastenUri = yup.InferType<typeof FASTEN_URI_SCHEMA>;
+
+/**
+ * Validates that the given response payload is as expected.
+ * @param {any} payload - the response payload.
+ * @returns {boolean} - whether or not the payload is type-safe for {@link FastenUri}.
+ */
+export function isValidFastenUrisResponsePayload(
+  payload: any
+): payload is FastenUri {
+  return FASTEN_URI_SCHEMA.isValidSync(payload);
+}

--- a/src/requests/payloads/fasten-uri-payload.ts
+++ b/src/requests/payloads/fasten-uri-payload.ts
@@ -20,10 +20,10 @@ export const FASTEN_URI_SCHEMA = yup
     uri: yup.string().required(),
 
     /** User-friendly, formatted string of the class name. */
-    className: yup.string().nullable(),
+    className: yup.string().optional(),
 
     /** User-friendly, formatted string of the method name. */
-    functionOrAttributeName: yup.string().nullable(),
+    functionOrAttributeName: yup.string().optional(),
 
     /** User-friendly, formatted string of method's arguments. */
     args: yup.array().of(short_uri_schema).required(),
@@ -32,19 +32,19 @@ export const FASTEN_URI_SCHEMA = yup
     returnType: short_uri_schema,
 
     /** Raw string identifying forge of the entity. */
-    rawForge: yup.string().nullable(),
+    rawForge: yup.string().optional(),
 
     /** Raw string identifying product of the entity. */
-    rawProduct: yup.string().nullable(),
+    rawProduct: yup.string().optional(),
 
     /** Raw string identifying version of the entity. */
-    rawVersion: yup.string().nullable(),
+    rawVersion: yup.string().optional(),
 
     /** Raw string identifying namespace of the entity. */
-    rawNamespace: yup.string().nullable(),
+    rawNamespace: yup.string().optional(),
 
     /** Raw string identifying whole entity. */
-    rawEntity: yup.string().nullable(),
+    rawEntity: yup.string().optional(),
   })
   .required();
 

--- a/src/requests/payloads/package-callable-payload.ts
+++ b/src/requests/payloads/package-callable-payload.ts
@@ -17,12 +17,6 @@ export const PACKAGE_CALLABLE_SCHEMA = yup
     /** The URI in the FASTEN system. */
     fasten_uri: FASTEN_URI_SCHEMA,
 
-    /** User-friendly, formatted string of method name. */
-    method_name: yup.string().nullable(),
-
-    /** User-friendly, formatted string of method arguments. */
-    method_args: yup.string().nullable(),
-
     /** Is the callable internal within the package? */
     is_internal_call: yup.boolean().required(),
 
@@ -79,8 +73,6 @@ export const defaultCallable: Callable = {
     rawForge: "mvn",
     rawNamespace: "",
   },
-  method_name: "",
-  method_args: "",
   is_internal_call: true,
   line_start: 0,
   line_end: 0,

--- a/src/requests/payloads/package-callable-payload.ts
+++ b/src/requests/payloads/package-callable-payload.ts
@@ -1,5 +1,6 @@
 import * as yup from "yup";
 import { array } from "yup";
+import { FASTEN_URI_SCHEMA } from "./fasten-uri-payload";
 
 /**
  * Validation schema for {@link Callable}.
@@ -14,7 +15,7 @@ export const PACKAGE_CALLABLE_SCHEMA = yup
     module_id: yup.number().integer().positive().required(),
 
     /** The URI in the FASTEN system. */
-    fasten_uri: yup.string().required(),
+    fasten_uri: FASTEN_URI_SCHEMA,
 
     /** User-friendly, formatted string of method name. */
     method_name: yup.string().nullable(),
@@ -62,7 +63,22 @@ export type CallablesResponsePayload = Callable[];
 export const defaultCallable: Callable = {
   id: 0,
   module_id: 0,
-  fasten_uri: "",
+  fasten_uri: {
+    args: [],
+    rawProduct: "",
+    rawEntity: "",
+    className: "",
+    functionOrAttributeName: "",
+    rawVersion: "1.0.0",
+    uri: "",
+    returnType: {
+      rawEntity: "Logger",
+      className: "Logger",
+      uri: "Logger",
+    },
+    rawForge: "mvn",
+    rawNamespace: "",
+  },
   method_name: "",
   method_args: "",
   is_internal_call: true,


### PR DESCRIPTION
## Description
Pretify the way how frontend renders the list of callables. It now includes simple names, instead of full URIs, and interactable elements such as aguments and return types that link to corresponding modules.

## Motivation and context
This is needed for better User Experience. This way, web becomes much more readable and feature-full platform,

## Additional context
Prerequisite: [fasten-project/fasten!30](https://github.com/fasten-project/fasten/pull/360)
